### PR TITLE
Specify default SSH identity file

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a constant work-in-progress, but feel to look around for anything useful
 
 ### Prepare on existing system
 
-- Backup SSH keys & config
+- Backup SSH keys & config (recommended only for reinstalling the same machine)
 ```
 cd <backup folder>
 tar -cz ~/.ssh | gpg --yes -c -o ./ssh-backup.tgz.gpg
@@ -25,7 +25,11 @@ tar -cz ~/.gnupg | gpg --yes -c -o ./gnupg-backup.tgz.gpg
 
 ### Setup new environment
 
-- Restore SSH keys & config
+- Generate a new SSH key (recommended for new machines)
+```
+ssh-keygen -t ed25519 -a 64 -C "your.email@example.com"
+```
+- Restore SSH keys & config (only if reinstalling the same machine)
 ```
 cd ~
 rm -rf .ssh

--- a/install.sh
+++ b/install.sh
@@ -19,6 +19,7 @@ mkdir -p "${HOME}/.config/Code/User" \
          "${HOME}/.vim/bundle" \
          "${HOME}/.vim/backups" \
          "${HOME}/.vim/swaps" \
+         "${HOME}/.ssh" \
          "${HOME}/NAS/Pictures" \
          "${HOME}/NAS/Archive" \
          "${HOME}/NAS/Videos" \
@@ -52,6 +53,7 @@ ln -sT "${BASEDIR}/config/Code/settings.json"                 "${HOME}/.config/C
 ln -sT "${BASEDIR}/config/Code/keybindings.json"              "${HOME}/.config/Code/User/keybindings.json"          || true
 ln -sT "${BASEDIR}/config/fish/config.fish"                   "${HOME}/.config/fish/config.fish"                    || true
 ln -sT "${BASEDIR}/config/fish/fish_plugins"                  "${HOME}/.config/fish/fish_plugins"                   || true
+ln -sT "${BASEDIR}/ssh/config"                                "${HOME}/.ssh/config"                                 || true
 ln -sT "${BASEDIR}/config/ulauncher"                          "${HOME}/.config/ulauncher"                           || true
 ln -sT "${HOME}/Dropbox/notes/idid.log"                       "${HOME}/.idid.log"                                   || true
 

--- a/ssh/config
+++ b/ssh/config
@@ -1,0 +1,7 @@
+Host *
+  AddKeysToAgent yes
+  HashKnownHosts yes
+  ServerAliveInterval 60
+  ServerAliveCountMax 3
+  IdentitiesOnly yes
+  IdentityFile ~/.ssh/id_ed25519


### PR DESCRIPTION
### Motivation
- Make the shared SSH client configuration a canonical, shareable dotfile and explicitly set the default identity file.
- Ensure the installer creates `~/.ssh` and links the managed config so SSH settings are consistent across machines.
- Clarify when to restore existing SSH keys versus generating a new key during reinstall or new machine setup.
- Provide a secure `ssh-keygen` example to help users create a new key.

### Description
- Add `IdentityFile ~/.ssh/id_ed25519` to `ssh/config` and retain common options like `AddKeysToAgent`, `HashKnownHosts`, `ServerAliveInterval`, `ServerAliveCountMax`, and `IdentitiesOnly`.
- Move the shared SSH config to top-level `ssh/config` (previously `config/ssh/config`) as a repository-managed dotfile.
- Update `install.sh` to create `${HOME}/.ssh` and symlink `ssh/config` into `~/.ssh/config` using `ln -sT`.
- Update `README.md` to include SSH backup/restore guidance and recommend a secure `ssh-keygen` command for new machines (`ssh-keygen -t ed25519 -a 64 -C "your.email@example.com"`).

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695843e1b6cc833186119be1f5e47690)